### PR TITLE
update open jdk 

### DIFF
--- a/kanban-app/Dockerfile
+++ b/kanban-app/Dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.6.1-jdk-8-slim AS build
+FROM maven:3.8.1-openjdk-16-slim AS build
 RUN mkdir -p /workspace
 WORKDIR /workspace
 COPY pom.xml /workspace
 COPY src /workspace/src
 RUN mvn -f pom.xml clean package
 
-FROM openjdk:8-alpine
+FROM openjdk:16.0.1-alpine
 COPY --from=build /workspace/target/*.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
update open jdk should fix [ERROR] /workspace/src/integration-test/java/za.co.bmw.kanban/service/KanbanServiceITCase.java:[3,22] package jdk.vm.ci.meta does not exist