### PR TITLE
Fixing Fatal error compiling

### DIFF
--- a/kanban-app/pom.xml
+++ b/kanban-app/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.8</version>
+			<version>1.18.20</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Fixing Fatal error compiling: java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x63dc3420) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module 

Solution References:
https://stackoverflow.com/a/65382080
https://github.com/projectlombok/lombok/issues/2681#issuecomment-812288829