### PR TITLE
Fix ERROR: manifest for openjdk:16.0.1-alpine not found

### DIFF
--- a/kanban-app/Dockerfile
+++ b/kanban-app/Dockerfile
@@ -5,7 +5,7 @@ COPY pom.xml /workspace
 COPY src /workspace/src
 RUN mvn -f pom.xml clean package
 
-FROM openjdk:16.0.1-alpine
+FROM amd64/openjdk:16-alpine
 COPY --from=build /workspace/target/*.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
Fix ERROR: Service 'kanban-app' failed to build: manifest for openjdk:16.0.1-alpine not found

Specify amd64/openjdk:<version>-alpine